### PR TITLE
Mu4e: Improve gmail checks

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -178,7 +178,7 @@ account address and "gmail" in the account maildir, as well as accounts listed
 in ~+mu4e-gmail-accounts~. Any domain can be specified, so G Suite accounts can
 benefit from the integrations:
 #+begin_src emacs-lisp
-;; if "gmail" is missing from the maildir, the account must be listed here
+;; if "gmail" is missing from the address or maildir, the account must be listed here
 (setq +mu4e-gmail-accounts '(("hlissner@gmail.com" . "/hlissner")
                              ("example@example.com" . "/example")))
 #+end_src
@@ -188,7 +188,6 @@ presents messages over IMAP:
 #+begin_src emacs-lisp
 ;; don't need to run cleanup after indexing for gmail
 (setq mu4e-index-cleanup nil
-
       ;; because gmail uses labels as folders we can use lazy check since
       ;; messages don't really "move"
       mu4e-index-lazy-check t)

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -173,10 +173,14 @@ Then configure Emacs to use your email address:
 With the =+gmail= flag, integrations are applied which account for the different
 behaviour of Gmail.
 
-The integrations are applied when using addresses which contain =@gmail.com= or
-have =gmail= in the maildir name. You can use ~+mu4e-gmail-addresses~ when you want
-an address to be treated as such but it meets neither conditions (e.g. with
-Gsuite).
+The integrations are applied to addresses listed in ~+mu4e-gmail-addresses~. The
+relative location of the maildir should also be listed:
+#+begin_src emacs-lisp
+(setq +mu4e-gmail-addresses '(("example@gmail.com" . "/gmail")
+                              ("example@example.com" . "/example")))
+#+end_src
+
+Any domain can be specified, so G Suite accounts can benefit from the integrations.
 
 ** OrgMsg
 With the =+org= flag, =org-msg= is installed, and ~org-msg-mode~ is enabled before

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -194,6 +194,11 @@ presents messages over IMAP:
       mu4e-index-lazy-check t)
 #+end_src
 
+Also, note that Gmail's IMAP settings must have "When I mark a message in IMAP
+as deleted: Auto-Expunge off - Wait for the client to update the server." and
+"When a message is marked as deleted and expunged from the last visible IMAP
+folder: Move the message to the trash" for the integrations to work as expected.
+
 ** OrgMsg
 With the =+org= flag, =org-msg= is installed, and ~org-msg-mode~ is enabled before
 composing the first message. To disable ~org-msg-mode~ by default, simply

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -173,14 +173,26 @@ Then configure Emacs to use your email address:
 With the =+gmail= flag, integrations are applied which account for the different
 behaviour of Gmail.
 
-The integrations are applied to addresses listed in ~+mu4e-gmail-addresses~. The
-relative location of the maildir should also be listed:
+The integrations are applied to addresses listed in ~+mu4e-gmail-addresses~. Any
+domain can be specified, so G Suite accounts can benefit from the integrations.
+The relative location of the maildir should also be listed:
 #+begin_src emacs-lisp
 (setq +mu4e-gmail-addresses '(("example@gmail.com" . "/gmail")
                               ("example@example.com" . "/example")))
 #+end_src
 
-Any domain can be specified, so G Suite accounts can benefit from the integrations.
+
+
+If you only use Gmail, you can improve performance due to the way Gmail
+presents messages over IMAP:
+#+begin_src emacs-lisp
+;; don't need to run cleanup after indexing for gmail
+(setq mu4e-index-cleanup nil
+
+      ;; because gmail uses labels as folders we can use lazy check since
+      ;; messages don't really "move"
+      mu4e-index-lazy-check t)
+#+end_src
 
 ** OrgMsg
 With the =+org= flag, =org-msg= is installed, and ~org-msg-mode~ is enabled before

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -173,15 +173,15 @@ Then configure Emacs to use your email address:
 With the =+gmail= flag, integrations are applied which account for the different
 behaviour of Gmail.
 
-The integrations are applied to addresses listed in ~+mu4e-gmail-addresses~. Any
-domain can be specified, so G Suite accounts can benefit from the integrations.
-The relative location of the maildir should also be listed:
+The integrations are applied to addresses with /both/ "@gmail.com" in the
+account address and "gmail" in the account maildir, as well as accounts listed
+in ~+mu4e-gmail-accounts~. Any domain can be specified, so G Suite accounts can
+benefit from the integrations:
 #+begin_src emacs-lisp
-(setq +mu4e-gmail-addresses '(("example@gmail.com" . "/gmail")
-                              ("example@example.com" . "/example")))
+;; if "gmail" is missing from the maildir, the account must be listed here
+(setq +mu4e-gmail-accounts '(("hlissner@gmail.com" . "/hlissner")
+                             ("example@example.com" . "/example")))
 #+end_src
-
-
 
 If you only use Gmail, you can improve performance due to the way Gmail
 presents messages over IMAP:

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -387,8 +387,12 @@ Must be set before org-msg is loaded to take effect.")
 (when (featurep! +gmail)
   (after! mu4e
     (defvar +mu4e-gmail-accounts nil
-      "An alist of gmail addresses of the format
-\((\"address@domain.com\" . \"account-maildir\"))")
+      "Gmail accounts that do not contain \"gmail\" in address and maildir.
+
+An alist of Gmail addresses of the format \((\"username@domain.com\" . \"account-maildir\"))
+to which Gmail integrations (behind the `+gmail' flag of the `mu4e' module) should be applied.
+
+See `+mu4e-msg-gmail-p' and `mu4e-sent-messages-behavior'.")
 
     ;; don't save message to Sent Messages, Gmail/IMAP takes care of this
     (setq mu4e-sent-messages-behavior
@@ -400,14 +404,14 @@ Must be set before org-msg is loaded to take effect.")
 
     (defun +mu4e-msg-gmail-p (msg)
       (let ((root-maildir
-             (replace-regexp-in-string
-              "/.*" "" (substring (mu4e-message-field msg :maildir) 1))))
+             (replace-regexp-in-string "/.*" ""
+                                       (substring (mu4e-message-field msg :maildir) 1))))
         (or (string-match-p "gmail" root-maildir)
             (member root-maildir (mapcar #'cdr +mu4e-gmail-accounts)))))
 
     ;; In my workflow, emails won't be moved at all. Only their flags/labels are
     ;; changed. Se we redefine the trash and refile marks not to do any moving.
-    ;; However, the real magic happens in `+mu4e|gmail-fix-flags'.
+    ;; However, the real magic happens in `+mu4e-gmail-fix-flags-h'.
     ;;
     ;; Gmail will handle the rest.
     (defun +mu4e--mark-seen (docid _msg target)

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -396,14 +396,7 @@ Must be set before org-msg is loaded to take effect.")
             (if (or (string-match-p "@gmail.com\\'" (message-sendmail-envelope-from))
                     (member (message-sendmail-envelope-from)
                             (mapcar #'car +mu4e-gmail-addresses)))
-                'delete 'sent))
-
-          ;; don't need to run cleanup after indexing for gmail
-          mu4e-index-cleanup nil
-
-          ;; because gmail uses labels as folders we can use lazy check since
-          ;; messages don't really "move"
-          mu4e-index-lazy-check t)
+                'delete 'sent)))
 
     (defun +mu4e-msg-gmail-p (msg)
       (or (string-match-p "gmail" (mu4e-message-field msg :maildir))

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -386,23 +386,24 @@ Must be set before org-msg is loaded to take effect.")
 
 (when (featurep! +gmail)
   (after! mu4e
-    (defvar +mu4e-gmail-addresses nil
+    (defvar +mu4e-gmail-accounts nil
       "An alist of gmail addresses of the format
-\((\"address@domain.com\" . \"/maildir\"))")
+\((\"address@domain.com\" . \"account-maildir\"))")
 
     ;; don't save message to Sent Messages, Gmail/IMAP takes care of this
     (setq mu4e-sent-messages-behavior
           (lambda () ;; TODO make use +mu4e-msg-gmail-p
             (if (or (string-match-p "@gmail.com\\'" (message-sendmail-envelope-from))
                     (member (message-sendmail-envelope-from)
-                            (mapcar #'car +mu4e-gmail-addresses)))
+                            (mapcar #'car +mu4e-gmail-accounts)))
                 'delete 'sent)))
 
     (defun +mu4e-msg-gmail-p (msg)
-      (or (string-match-p "gmail" (mu4e-message-field msg :maildir))
-          (cl-some
-           (doom-rpartial #'string-prefix-p (mu4e-message-field msg :maildir))
-           (mapcar #'cdr +mu4e-gmail-addresses))))
+      (let ((root-maildir
+             (replace-regexp-in-string
+              "/.*" "" (substring (mu4e-message-field msg :maildir) 1))))
+        (or (string-match-p "gmail" root-maildir)
+            (member root-maildir (mapcar #'cdr +mu4e-gmail-accounts)))))
 
     ;; In my workflow, emails won't be moved at all. Only their flags/labels are
     ;; changed. Se we redefine the trash and refile marks not to do any moving.


### PR DESCRIPTION
I can't comment on the Mu4e PR because Henrik's locked the repo for the week, so I guess I'm doing a PR to a PR?

I'm guessing your Gmail account had a maildir with "gmail" in the name, because the to-from parsing doesn't work. `(mu4e-message-field msg :to/:from)` return alists (because mail can be to many people) with keys of names and values of email addresses, so we would have to get the values with `mapcar #'cdr` and then do something like `seq-intersection` to determine if any personal address were in the "To" or "From" address lists. I don't know if this makes sense, since all Gmail messages will be in Gmail maildirs anyway, and we could get false positives when marking messages in other accounts' maildirs. For example, a message in a non-Gmail maildir that was also sent to your Gmail, or a message in the Sent maildir of another personal account that you sent to your Gmail. The maildir way seems foolproof.

I just ended up changing `+mu4e-gmail-addresses` to be required rather than only for extras, since maildir names might not have Gmail in them. It seemed like telling users to list only Gmail accounts with maildirs that don't have "gmail" in the path might be more confusing than just having them list them all outright?